### PR TITLE
Handle incomplete status message from socket (fixes #432)

### DIFF
--- a/openvpn.js
+++ b/openvpn.js
@@ -60,7 +60,6 @@ class client extends EventEmitter {
           this.procData(itm.toString());
         } catch (error) {
           console.log(`Could not process data item ${itm.toString()}`);
-          console.log(itm);
           console.log(error);
         }});
     })

--- a/openvpn.js
+++ b/openvpn.js
@@ -55,7 +55,14 @@ class client extends EventEmitter {
     this.connected = false
     this.socket.on('data', data => {
       const items = data.toString().split('\r\n').filter(itm => itm.length)
-      items.forEach(itm => this.procData(itm.toString()))
+      items.forEach(itm => {
+        try {
+          this.procData(itm.toString());
+        } catch (error) {
+          console.log(`Could not process data item ${itm.toString()}`);
+          console.log(itm);
+          console.log(error);
+        }});
     })
     this.socket.on('error', () => {
       this.connected = false
@@ -96,14 +103,19 @@ class client extends EventEmitter {
       }
     } else if (data.startsWith('ROUTING_TABLE') && this.state === STATE.status) {
       const props = data.split('\t').slice(1, data.length + 1)
-      const [pub, port] = props[this.clientProps.indexOf('Real Address')].split(':')
-      const client = Array.from(this.clients.values()).find((client) => client.pub === pub && client.port === port && this.netmask.contains(client.pub))
-      if (client) {
-        const vpnClient = this.clientProps.reduce((acc, prop, idx) => {
-          acc[prop] = prepProperty(props[idx])
-          return acc
-        }, {})
-        mkClient(vpnClient, client)
+      const realAddressIndex = this.clientProps.indexOf('Real Address');
+      if (realAddressIndex < props.length) {
+        const [pub, port] = props[realAddressIndex].split(':')
+        const client = Array.from(this.clients.values()).find((client) => client.pub === pub && client.port === port && this.netmask.contains(client.pub))
+        if (client) {
+          const vpnClient = this.clientProps.reduce((acc, prop, idx) => {
+            acc[prop] = prepProperty(props[idx])
+            return acc
+          }, {})
+          mkClient(vpnClient, client)
+        }
+      } else {
+         console.log(`props truncated ${data}`);
       }
     } else if (data.startsWith('END') && this.state === STATE.status) {
       this.oldClients.forEach((client, key) => {


### PR DESCRIPTION
Incomplete status messages returned from openvpn socket cause runtime exceptions in parsing code. Catch any problem in socket-handler and address incomplete status lines directly to avoid exception.