### PR TITLE
Handle unknown clients

### DIFF
--- a/server.js
+++ b/server.js
@@ -67,6 +67,9 @@ const logEvent = event => {
 const clientToEntry = client => {
   const loc = cityLookup(client.pub)
   client.node = client.cn
+  if (client.node === undefined) {
+    client.node = "Unknown_" + client.pub;
+  }
   if (loc) {
     client.country_code = loc.country.iso_code
     client.country_name = loc.country.names.en


### PR DESCRIPTION
cn is not known if login fails. 'undefined' node causes Sequelize to abort server.

Found this after illegal login attempts from attackers which got stuck because of a missing client certificate.